### PR TITLE
chore(dokploy): switch to Dockerfile build (nginx) for reliability + …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Simple Nginx image to serve the static landing page
+FROM nginx:1.25-alpine
+
+# Remove default config and use our own
+RUN rm -f /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy static assets
+COPY . /usr/share/nginx/html
+
+# Ensure proper permissions
+RUN chmod -R 755 /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/dokploy.yaml
+++ b/dokploy.yaml
@@ -6,21 +6,15 @@
 version: 1
 name: coachlibre-landing
 
-static:
-  buildType: Static
-  publishDir: "."
-  # Optional: custom headers
-  headers:
-    - path: "/"
-      headers:
-        - name: "Cache-Control"
-          value: "public, max-age=600"
-        - name: "X-Frame-Options"
-          value: "SAMEORIGIN"
-  # Optional: error/redirect handling
-  routes:
-    - path: "/**"
-      status: 200
+dockerfile:
+  buildType: Dockerfile
+  context: "."
+  dockerfilePath: "./Dockerfile"
+  # Dokploy will expose the container through Traefik. Internal port must match Nginx listen.
+  internalPort: 80
+  env: []
+  # Optional healthcheck path (dokploy may support custom checks depending on version)
+  healthcheckPath: "/"
 
 # Notes:
 # - Dokploy should be set to watch your GitHub repo/branch.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+server {
+  listen 80;
+  server_name _;
+
+  # Root points to the directory with index.html
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Default: serve static files
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  # Basic security headers
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+}


### PR DESCRIPTION
…auto-redeploy\n\n- Add Dockerfile (nginx:alpine) and nginx.conf\n- Update dokploy.yaml to use Dockerfile build type and internalPort 80\n\nCo-authored-by: openhands <openhands@all-hands.dev>